### PR TITLE
Upgrade to Swift 2.3

### DIFF
--- a/ImagePickerSheetController/ImagePickerSheetController.xcodeproj/project.pbxproj
+++ b/ImagePickerSheetController/ImagePickerSheetController.xcodeproj/project.pbxproj
@@ -7,14 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4944CA851B8DB7F3007EA349 /* SheetActionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4944CA841B8DB7F3007EA349 /* SheetActionCollectionViewCell.swift */; settings = {ASSET_TAGS = (); }; };
+		4944CA851B8DB7F3007EA349 /* SheetActionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4944CA841B8DB7F3007EA349 /* SheetActionCollectionViewCell.swift */; };
 		494505AC1B2201AF00EF9ADC /* KIFExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494505AB1B2201AF00EF9ADC /* KIFExtensions.swift */; };
 		494505AE1B22022F00EF9ADC /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49A408461B21854300D6005C /* CoreGraphics.framework */; };
 		494505B11B22026600EF9ADC /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49A408481B2186D500D6005C /* IOKit.framework */; };
-		494B3B711B8EF3CB004B467C /* ImagePickerSheetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494B3B701B8EF3CB004B467C /* ImagePickerSheetController.swift */; settings = {ASSET_TAGS = (); }; };
+		494B3B711B8EF3CB004B467C /* ImagePickerSheetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494B3B701B8EF3CB004B467C /* ImagePickerSheetController.swift */; };
 		495E5F551B9DE84D004729E6 /* KIF.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49A408441B21853E00D6005C /* KIF.framework */; };
 		495F89A91B394288006B9BA4 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 49DC4AAD1B14FB9A00B4E78E /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		49665AD71B8F2DC6005AA666 /* SheetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49665AD61B8F2DC6005AA666 /* SheetController.swift */; settings = {ASSET_TAGS = (); }; };
+		49665AD71B8F2DC6005AA666 /* SheetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49665AD61B8F2DC6005AA666 /* SheetController.swift */; };
 		4981CB031B8B246000A09750 /* SheetPreviewCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4981CAFD1B8B246000A09750 /* SheetPreviewCollectionViewCell.swift */; };
 		4981CB041B8B246000A09750 /* PreviewCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4981CAFF1B8B246000A09750 /* PreviewCollectionViewCell.swift */; };
 		4981CB051B8B246000A09750 /* PreviewCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4981CB001B8B246000A09750 /* PreviewCollectionView.swift */; };
@@ -22,12 +22,12 @@
 		4981CB071B8B246000A09750 /* PreviewSupplementaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4981CB021B8B246000A09750 /* PreviewSupplementaryView.swift */; };
 		4981CB091B8B255A00A09750 /* SheetCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4981CB081B8B255A00A09750 /* SheetCollectionViewCell.swift */; };
 		4989232F1B9B05CB00D68C8E /* KIF.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 49A408441B21853E00D6005C /* KIF.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		499E65CF1B8E317C005B807F /* SheetCollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499E65CE1B8E317C005B807F /* SheetCollectionViewLayout.swift */; settings = {ASSET_TAGS = (); }; };
-		49A93AE81B9CC0F100EE8A40 /* PresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A93AE71B9CC0F100EE8A40 /* PresentationTests.swift */; settings = {ASSET_TAGS = (); }; };
-		49A93AF11B9CC15A00EE8A40 /* DismissalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A93AF01B9CC15A00EE8A40 /* DismissalTests.swift */; settings = {ASSET_TAGS = (); }; };
-		49A93AF31B9CCB3900EE8A40 /* AddingActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A93AF21B9CCB3900EE8A40 /* AddingActionTests.swift */; settings = {ASSET_TAGS = (); }; };
-		49A93AF51B9CCBA900EE8A40 /* ActionHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A93AF41B9CCBA900EE8A40 /* ActionHandlingTests.swift */; settings = {ASSET_TAGS = (); }; };
-		49A93AF71B9CCC9500EE8A40 /* ImageSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A93AF61B9CCC9500EE8A40 /* ImageSelectionTests.swift */; settings = {ASSET_TAGS = (); }; };
+		499E65CF1B8E317C005B807F /* SheetCollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499E65CE1B8E317C005B807F /* SheetCollectionViewLayout.swift */; };
+		49A93AE81B9CC0F100EE8A40 /* PresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A93AE71B9CC0F100EE8A40 /* PresentationTests.swift */; };
+		49A93AF11B9CC15A00EE8A40 /* DismissalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A93AF01B9CC15A00EE8A40 /* DismissalTests.swift */; };
+		49A93AF31B9CCB3900EE8A40 /* AddingActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A93AF21B9CCB3900EE8A40 /* AddingActionTests.swift */; };
+		49A93AF51B9CCBA900EE8A40 /* ActionHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A93AF41B9CCBA900EE8A40 /* ActionHandlingTests.swift */; };
+		49A93AF71B9CCC9500EE8A40 /* ImageSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A93AF61B9CCC9500EE8A40 /* ImageSelectionTests.swift */; };
 		49DC4A571B14F1BC00B4E78E /* ImagePickerSheetController.h in Headers */ = {isa = PBXBuildFile; fileRef = 49DC4A561B14F1BC00B4E78E /* ImagePickerSheetController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		49DC4A5D1B14F1BC00B4E78E /* ImagePickerSheetController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49DC4A511B14F1BC00B4E78E /* ImagePickerSheetController.framework */; };
 		49DC4A641B14F1BC00B4E78E /* ImagePickerSheetControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DC4A631B14F1BC00B4E78E /* ImagePickerSheetControllerTests.swift */; };
@@ -374,14 +374,17 @@
 				TargetAttributes = {
 					49DC4A501B14F1BC00B4E78E = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 					49DC4A5B1B14F1BC00B4E78E = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 						TestTargetID = 49DC4A851B14F31500B4E78E;
 					};
 					49DC4A851B14F31500B4E78E = {
 						CreatedOnToolsVersion = 6.3.1;
 						DevelopmentTeam = 5953RHWYWT;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -629,6 +632,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.laurinbrandner.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -647,6 +651,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.laurinbrandner.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -663,6 +668,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.laurinbrandner.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
 			name = Debug;
@@ -676,6 +682,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.laurinbrandner.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
 			name = Release;
@@ -695,6 +702,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.laurinbrandner.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -709,6 +717,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.laurinbrandner.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/ImagePickerSheetController/ImagePickerSheetController/AnimationController.swift
+++ b/ImagePickerSheetController/ImagePickerSheetController/AnimationController.swift
@@ -23,9 +23,7 @@ class AnimationController: NSObject {
     // MARK: - Animation
     
     private func animatePresentation(context: UIViewControllerContextTransitioning) {
-        guard let containerView = context.containerView() else {
-            return
-        }
+        let containerView = context.containerView()
         
         containerView.addSubview(imagePickerSheetController.view)
         
@@ -42,9 +40,7 @@ class AnimationController: NSObject {
     }
     
     private func animateDismissal(context: UIViewControllerContextTransitioning) {
-        guard let containerView = context.containerView() else {
-            return
-        }
+        let containerView = context.containerView()
         
         UIView.animateWithDuration(transitionDuration(context), delay: 0, options: .CurveEaseIn, animations: { () -> Void in
             self.imagePickerSheetController.sheetCollectionView.frame.origin.y = containerView.bounds.maxY


### PR DESCRIPTION
Hey, this adds compatibility with Swift 2.3 for those who need to upgrade step by step instead of upgrading straight to Swift 3.0.
You should probably create a dedicated Swift-2.3 branch for that, don't merge it into master :)
Cheers