### PR TITLE
Removes retain cycle prevention

### DIFF
--- a/ImagePickerSheetController/ImagePickerSheetController/ImagePickerSheetController.swift
+++ b/ImagePickerSheetController/ImagePickerSheetController/ImagePickerSheetController.swift
@@ -37,11 +37,7 @@ open class ImagePickerSheetController: UIViewController {
     fileprivate lazy var sheetController: SheetController = {
         let controller = SheetController(previewCollectionView: self.previewCollectionView)
         controller.actionHandlingCallback = { [weak self] in
-            self?.dismiss(animated: true, completion: { _ in
-                // Possible retain cycle when action handlers hold a reference to the IPSC
-                // Remove all actions to break it
-                controller.removeAllActions()
-            })
+            self?.dismiss(animated: true, completion: nil)
         }
         
         return controller

--- a/ImagePickerSheetController/ImagePickerSheetController/ImagePickerSheetController.swift
+++ b/ImagePickerSheetController/ImagePickerSheetController/ImagePickerSheetController.swift
@@ -31,13 +31,19 @@ public enum ImagePickerMediaType {
     
 }
 
+fileprivate let imageManager = PHCachingImageManager()
+
 @available(iOS 9.0, *)
 open class ImagePickerSheetController: UIViewController {
     
     fileprivate lazy var sheetController: SheetController = {
         let controller = SheetController(previewCollectionView: self.previewCollectionView)
         controller.actionHandlingCallback = { [weak self] in
-            self?.dismiss(animated: true, completion: nil)
+            self?.dismiss(animated: true, completion: { _ in
+                // Possible retain cycle when action handlers hold a reference to the IPSC
+                // Remove all actions to break it
+                controller.removeAllActions()
+            })
         }
         
         return controller
@@ -108,8 +114,6 @@ open class ImagePickerSheetController: UIViewController {
         
         return options
     }()
-    
-    fileprivate let imageManager = PHCachingImageManager()
     
     /// Whether the image preview has been elarged. This is the case when at least once
     /// image has been selected.
@@ -253,7 +257,7 @@ open class ImagePickerSheetController: UIViewController {
                 }
             }
             
-            self.imageManager.requestImageData(for: asset, options: requestOptions) { data, _, _, info in
+            imageManager.requestImageData(for: asset, options: requestOptions) { data, _, _, info in
                 if data != nil {
                     self.assets.append(asset)
                 }

--- a/ImagePickerSheetController/ImagePickerSheetController/Sheet/SheetController.swift
+++ b/ImagePickerSheetController/ImagePickerSheetController/Sheet/SheetController.swift
@@ -147,10 +147,6 @@ class SheetController: NSObject {
         reloadActionItems()
     }
     
-    func removeAllActions() {
-        actions = []
-        reloadActionItems()
-    }
     
     fileprivate func handleAction(_ action: ImagePickerAction) {
         actionHandlingCallback?()

--- a/ImagePickerSheetController/ImagePickerSheetController/Sheet/SheetController.swift
+++ b/ImagePickerSheetController/ImagePickerSheetController/Sheet/SheetController.swift
@@ -147,6 +147,10 @@ class SheetController: NSObject {
         reloadActionItems()
     }
     
+    func removeAllActions() {
+        actions = []
+        reloadActionItems()
+    }
     
     fileprivate func handleAction(_ action: ImagePickerAction) {
         actionHandlingCallback?()


### PR DESCRIPTION
On September 18th, code was added with the aim of preventing a retain cycle. This code inadvertantly creates a crash if the user has denied photo access and the user dismisses the action sheet. It has to do with setting `actions = nil` in SheetController.